### PR TITLE
Add copycopter gemset to rvm

### DIFF
--- a/.rvmrc
+++ b/.rvmrc
@@ -1,1 +1,1 @@
-rvm 1.9.2
+rvm 1.9.2@copycopterserver


### PR DESCRIPTION
Instead of muddying up the global gemset in 1.9.2, add a gemset to keep it clean and isolated
