### PR TITLE
Issue 60 - screen slides right with Firefox

### DIFF
--- a/public/stylesheets/sass/_versions.scss
+++ b/public/stylesheets/sass/_versions.scss
@@ -21,6 +21,7 @@ li {
     padding: 8px;
     margin-bottom: 0;
     width: 580px;
+    clear:left;
     @include box-shadow(inset 0 0 5px #e9e9e9);
 
     .wysiwyg {


### PR DESCRIPTION
I think the issue here is down to the textarea being inside a li, which is being floated to the left.

Force a line-break for the text input, when viewing Copycopter in Firefox.

We expect a line break anyway here, so this shouldn't break layouts on other browsers.

However, I can't see why the declaration here wouldn't make it to the compiled application.css file when I pushed it to my instance on heroku, and I'm unfamiliar with using bourbon for css layout.

Any pointers?
