### PR TITLE
Update docs to use latest minor release of client

### DIFF
--- a/app/views/projects/_installation_instructions.html.erb
+++ b/app/views/projects/_installation_instructions.html.erb
@@ -4,7 +4,7 @@
   <ol>
     <li>
       Add the copycopter_client gem to your bundler Gemfile:
-      <pre>gem 'copycopter_client', '2.0.0'</pre>
+      <pre>gem 'copycopter_client', '~> 2.0.1'</pre>
     </li>
 
     <li>


### PR DESCRIPTION
This should also allow users to catch subsequent minor releases without touching their gemfiles.
