### PR TITLE
Fix link to hello.png

### DIFF
--- a/app/views/blurbs/_new_blurb_instructions.html.erb
+++ b/app/views/blurbs/_new_blurb_instructions.html.erb
@@ -11,7 +11,7 @@
 
     <li>
       View the blurb in your application:
-      <img src='/images/hello.png'>
+      <img src='/assets/hello.png'>
     </li>
 
     <li>


### PR DESCRIPTION
The image link for hello.png in /app/views/blurbs/_new_blurb_instructions.html.erb was set to /images/ but should be set to /assets/
